### PR TITLE
fix(ci): skip Claude Code Review for fork and Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip fork PRs and Dependabot PRs (they don't have access to secrets)
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Fixes Claude Code Review workflow failures on Dependabot PRs by adding conditional checks to skip execution for:
- Fork PRs (external contributors)
- Dependabot PRs (automated dependency updates)

## Problem

GitHub Actions does not pass repository secrets to workflows triggered by fork PRs or Dependabot PRs for security reasons. This caused authentication failures when the Claude Code Review workflow tried to use `CLAUDE_CODE_OAUTH_TOKEN`.

Error message:
```
Environment variable validation failed:
- Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
```

## Solution

Added conditional check in `.github/workflows/claude-code-review.yml`:
```yaml
if: |
  github.event.pull_request.head.repo.full_name == github.repository &&
  github.event.pull_request.user.login != 'dependabot[bot]'
```

## Impact

✅ **Will run Claude Code Review:**
- PRs from repository collaborators on non-fork branches

❌ **Will skip Claude Code Review:**
- Dependabot PRs (CI tests still run)
- Fork PRs from external contributors

## Test Plan

- [x] Workflow syntax is valid
- [ ] Verify Dependabot PRs no longer fail on Claude Code Review
- [ ] Verify regular PRs still trigger Claude Code Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)